### PR TITLE
Fix tags scrollbar on Firefox & Edge

### DIFF
--- a/src/components/PublicComponents/Tags.vue
+++ b/src/components/PublicComponents/Tags.vue
@@ -64,6 +64,8 @@ export default {
   &::-webkit-scrollbar {
     display: none;
   }
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 
   .tags-item {
     display: flex;


### PR DESCRIPTION
火狐和旧 EdgeHTML 上的滚动条没有隐藏

- Tested: Firefox 77
- Preview:
![](https://i.loli.net/2020/06/12/ipYc4MZXTwLm5F8.jpg)


