### PR TITLE
General Firefox compatibility fix

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -85,7 +85,7 @@ export default {
 <style lang="less">
 #app {
   .page-container {
-    /deep/ .el-main {
+    .el-main {
       padding: 0px;
     }
   }

--- a/src/views/BBS/BBS.vue
+++ b/src/views/BBS/BBS.vue
@@ -29,6 +29,11 @@ export default {
   .iframe{
     height: 100%;
     width: 100%;
+
+    // fix: firefox replaced elements overflow
+    iframe {
+      display: block;
+    }
   }
 }
 </style>


### PR DESCRIPTION
This pr fixes two compatibility issue in Firefox, tested with latest 84.0 and ESR.

1. The 20px padding of el-main is not correctly removed when using v-deep selector.
![201223175258](https://user-images.githubusercontent.com/21136293/102986245-7a33a200-454b-11eb-9f2e-10f812ce4307.png)

2. The iframe in bbs page causes overflow scrolling due to the small space added below the replaced elemes in Firefox by default.
![201223180318](https://user-images.githubusercontent.com/21136293/102986258-7bfd6580-454b-11eb-8be0-1669c26aed42.png)
